### PR TITLE
Tests fix

### DIFF
--- a/test/generate/index.js
+++ b/test/generate/index.js
@@ -53,7 +53,7 @@ function generateAsyncMethodSpecs(thenChrome, namespace, method) {
         });
 
         beforeEach(() => {
-            chrome.reset();
+            chromeMethod.resetHistory();
             chrome.runtime.lastError = undefined;
         });
 
@@ -134,7 +134,7 @@ function generateSyncMethodSpecs(thenChrome, namespace, method) {
         });
 
         beforeEach(() => {
-            chrome.reset();
+            chromeMethod.resetHistory();
         });
 
         after(function () {


### PR DESCRIPTION
Since sinon@2.0.0 `stub.reset()` performs `stub.resetBehavior()` as well.

From [sinon documentation](http://sinonjs.org/releases/v2.1.0/stubs/):
```
stub.reset();
Resets both behaviour and history of the stub.
This is equivalent to calling both stub.resetBehavior() and stub.resetHistory()
Updated in sinon@2.0.0
```

So tests have been failing.