### PR TITLE
fix typedef of ChromeThenable

### DIFF
--- a/src/typedef.js
+++ b/src/typedef.js
@@ -1,5 +1,5 @@
 /**
- * @typedef Function ChromeThenable
+ * @typedef {Function} ChromeThenable
  * @returns {Promise}
  */
 


### PR DESCRIPTION
Hi, really I don't know if you support this package or not:) But.
There is an error in the autocomplete (in PhpStorm) - it doesn't understand `@typedef Function` without `{}`.
So all other definitions have `{}`, e.g. `@property {ChromeThenable} bookmarks.get`, but PhpStorm says that any of `ChromeThenable` methods (`windows.get`, `windows.getCurrent` and so on) `is not of Function type`.